### PR TITLE
Suggested improvement

### DIFF
--- a/notes
+++ b/notes
@@ -11,10 +11,10 @@
 
 set -e
 
-readonly NOTES_DIRECTORY="${NOTES_DIRECTORY:-"${HOME}/notes"}"
+readonly NOTES_DIRECTORY="${NOTES_DIRECTORY:-"${HOME}/Documents/Notes"}"
 readonly NOTES_EDITOR="${EDITOR}"
 
-readonly NOTES_FILE="$(date +%Y-%m).txt"
+readonly NOTES_FILE="$(date +%m_%Y).txt"
 readonly NOTES_PATH="${NOTES_DIRECTORY}/${NOTES_FILE}"
 
 if [ ! -d "${NOTES_DIRECTORY}" ]; then

--- a/notes
+++ b/notes
@@ -14,7 +14,7 @@ set -e
 readonly NOTES_DIRECTORY="${NOTES_DIRECTORY:-"${HOME}/Documents/Notes"}"
 readonly NOTES_EDITOR="${EDITOR}"
 
-readonly NOTES_FILE="$(date +%m_%Y).txt"
+readonly NOTES_FILE="$(date +%b_%Y).txt"
 readonly NOTES_PATH="${NOTES_DIRECTORY}/${NOTES_FILE}"
 
 if [ ! -d "${NOTES_DIRECTORY}" ]; then

--- a/notes
+++ b/notes
@@ -11,7 +11,7 @@
 
 set -e
 
-readonly NOTES_DIRECTORY="${NOTES_DIRECTORY:-"${HOME}/Documents/Notes"}"
+readonly NOTES_DIRECTORY="${NOTES_DIRECTORY:-${HOME}/Documents/Notes}"
 readonly NOTES_EDITOR="${EDITOR}"
 
 readonly NOTES_FILE="$(date +%b_%Y).txt"


### PR DESCRIPTION
Changed the date around to +%b_%Y.  This made sense to me so that I could see the month with name and the year the note was placed.  I also put the notes directory in Documents.  Also a personal preference.

The only real technical change I am suggesting was to remove what looked like extra quotes NOTES_DIRECTORY variable.   By looking at the overall statement, I did see what they were enclosing, but reading from left to right, the quotes looked redundant and off as to where they opened and closed.  They seemed to be inside other quotes.  Even removed, the script still works perfectly.  